### PR TITLE
fix: Change Websocket to Deno's native method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,18 @@ server.ts:
   import { Sono } from 'https://deno.land/x/sono@v1.1/mod.ts';
 
   const sono = new Sono();
+  import { Sono } from "./server.mts";
+  Deno.serve(async (req: Request) => {
+      return sono.connect(req);
+  });
+
 ```
 
 client.js:
 ```javascript
   import { SonoClient } from 'https://deno.land/x/sono@v1.1/src/sonoClient.js';
 
-  const sono = new SonoClient('ws://localhost:8080/ws');
+  const sono = new SonoClient('ws://localhost:8000/ws');
 
   sono.on('hello', (event) => {
     console.log(event, 'world')

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ server.ts:
   import { Sono } from 'https://deno.land/x/sono@v1.1/mod.ts';
 
   const sono = new Sono();
-  import { Sono } from "./server.mts";
   Deno.serve(async (req: Request) => {
       return sono.connect(req);
   });

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+    "name": "@sono/core",
+    "version": "1.2.0",
+    "exports": "./mod.ts"
+}

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,0 @@
-/**
- * Import and export necessary methods, types, and functions from the deno standard library.
- */
-export { serve, Server as DenoServer, serveTLS, ServerRequest } from "https://deno.land/std@0.96.0/http/server.ts";
-export { serveFile } from "https://deno.land/std@0.96.0/http/file_server.ts";
-export type { HTTPOptions, HTTPSOptions } from "https://deno.land/std@0.96.0/http/server.ts";
-export { acceptWebSocket, isWebSocketCloseEvent } from "https://deno.land/std@0.96.0/ws/mod.ts";
-export type { WebSocket } from "https://deno.land/std@0.96.0/ws/mod.ts";

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,3 @@
-import { WebSocket } from "../deps.ts";
 /**
  * Client class creates each client with unique id, WebSocket, and the channel client is set to
  */

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,10 +36,16 @@ export class Sono {
     return;
   }
 
+  /**
+   * connect method used in Deno.serve
+   * @param req - request from client
+   * @param callback - callback function
+   * @returns { Response }
+   */
   connect(
     req: Request,
     callback: () => void = () => console.log("websocket created")
-  ) {
+  ): Response {
     // @ts-ignore
     const { socket, response }: { socket: WebSocket; response: Response } = Deno.upgradeWebSocket(req);
     this.handleWs(socket);
@@ -47,7 +53,7 @@ export class Sono {
     return response;
   }
 
-  emit(message: string) {
+  emit(message: string): void {
     Object.values(this.clients).forEach((client) => {
       client.socket.send(JSON.stringify({ message }));
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,20 +1,19 @@
 import { Client } from "./client.ts";
 import { EventHandler } from "./eventhandler.ts";
 import { Packet } from "./packet.ts";
-import type { WebSocket } from "../deps.ts";
-import type { HTTPOptions } from "../deps.ts";
-import { serve, DenoServer, ServerRequest, serveFile, acceptWebSocket, isWebSocketCloseEvent } from "../deps.ts";
+
+
 /**
  * Class that handles WebSocket messages.
  * Uses Client objects and an EventHandler object
  * to send messages to Clients.
-*/
-
+ */
 export class Sono {
-  public server: DenoServer | null = null;
-  public hostname = 'localhost';
-  public clients: {[key: string]: Client} = {};
-  public channelsList: {[key: string]: Record<string, Client>} = {'home': {}};
+  public hostname = "localhost";
+  public clients: { [key: string]: Client } = {};
+  public channelsList: { [key: string]: Record<string, Client> } = {
+    home: {},
+  };
   public eventHandler: EventHandler;
   public lastClientId: number = 1000;
 
@@ -23,61 +22,35 @@ export class Sono {
    * binds handleWs to this and returns a Sono instance.
    */
   constructor() {
-
     this.eventHandler = new EventHandler();
     this.handleWs = this.handleWs.bind(this);
   }
 
-  // /**
-  //  * Start server listening on passed-in port number.
-  //  * @param {number} port - Port that Sono.server listens to.
-  //  */
-  // listen(port: number): DenoServer {
-  //   const options: HTTPOptions = {port};
-  //   this.server = serve(options);
-  //   this.awaitRequests(this.server);
-  //   return this.server;
-  // }
 
   /**
    * Adding a channel to channelsList object
    * @param { name } - name of channel
    */
-  channel(name: string, callback: () => void) :void {
+  channel(name: string, callback: () => void): void {
     this.channelsList[name] = {};
 
     callback();
     return;
   }
 
-  // /**
-  //  * awaitRequests handles requests to server and returns undefined
-  //  * @param { DenoServer } - Sono.server from which requests are sent from
-  //  */
-  // async awaitRequests(server: DenoServer):Promise<void> {
-  //   // iterate over async request objects to server
-  //   for await(const req of server) {
-  //     this.handler(req);
-  //   }
-  // }
-
-
-
-
-  connect(req: ServerRequest, callback: () => void){
-    const { conn, w:bufWriter, r:bufReader, headers } = req;
-    acceptWebSocket({conn, bufWriter, bufReader, headers})
-      .then(this.handleWs)
-      .catch(err => console.log(err, 'err'))
+  connect(req: Request, callback: () => void) {
+    // @ts-ignore
+    const { socket, response }: { socket: WebSocket, response: Response } = Deno.upgradeWebSocket(req);
+    this.handleWs(socket);
+    this.emit("new client connected");
     callback();
+    return response;
   }
 
-
-
-  emit(message: string){
-    Object.values(this.clients).forEach(client => {
-      client.socket.send(JSON.stringify({message}))
-    })
+  emit(message: string) {
+    Object.values(this.clients).forEach((client) => {
+      client.socket.send(JSON.stringify({ message }));
+    });
   }
 
   /**
@@ -86,49 +59,68 @@ export class Sono {
    * Events of socket are looped thru and dealt with accordingly
    * @param { WebSocket } - WebSocket connection from a client
    */
-  async handleWs (socket: WebSocket):Promise<void> {
+  handleWs(socket: WebSocket): void {
     // create new client, add to clients object, add client to home channel
 
     const client = new Client(socket, this.lastClientId);
-    this.lastClientId = client.id
+    this.lastClientId = client.id;
     this.clients[client.id] = client;
-    this.channelsList['home'][client.id] = client;
-
-    for await(const message of socket){
-      // if client sends close websocket event, delete client
-      if (isWebSocketCloseEvent(message) || typeof message !== 'string'){
-        delete this.channelsList[client.channel][client.id];
-        delete this.clients[client.id]
-        break;
-      }
-      const data: Packet = JSON.parse(message)
+    this.channelsList["home"][client.id] = client;
+    socket.addEventListener("close", () => {
+      delete this.channelsList[client.channel][client.id];
+      delete this.clients[client.id];
+    });
+    socket.addEventListener("open", () => {
+      console.log(client.id, " client connected!");
+    });
+    socket.addEventListener("message", (event) => {
+      const message = event.data;
+      console.log(message);
+      const data: Packet = JSON.parse(message);
       // const event = new Event(data.protocol)
       // const grab = data.payload.message;
 
       // depending on data.protocol, invoke an eventHandler method
-      switch(data.protocol) {
-        case 'message':
-          // console.log('case message', this.clients)
-          this.eventHandler.handleMessage(data, client, this.channelsList);
+      switch (data.protocol) {
+        case "message":
+          // console.log("case message", this.clients);
+          this.eventHandler.handleMessage(
+            data,
+            client,
+            this.channelsList
+          );
           break;
-        case 'broadcast':
-          this.eventHandler.broadcast(data, client, this.channelsList)
+        case "broadcast":
+          this.eventHandler.broadcast(
+            data,
+            client,
+            this.channelsList
+          );
           break;
-        case 'changeChannel':
-          this.channelsList = this.eventHandler.changeChannel(data, client, this.channelsList);
+        case "changeChannel":
+          this.channelsList = this.eventHandler.changeChannel(
+            data,
+            client,
+            this.channelsList
+          );
           // console.log('case channel', this.channelsList);
           break;
-        case 'directmessage':
+        case "directmessage":
           this.eventHandler.directMessage(data, client, this.clients);
           break;
-        case 'grab':
-          this.eventHandler.grab(data, client, this.clients, this.channelsList);
+        case "grab":
+          this.eventHandler.grab(
+            data,
+            client,
+            this.clients,
+            this.channelsList
+          );
           break;
         default:
           // this.eventHandler
           // console.log('default hit', data)
-          console.log('default case in testServer');
+          console.log("default case in testServer");
       }
-    }
+    });
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import { Client } from "./client.ts";
 import { EventHandler } from "./eventhandler.ts";
 import { Packet } from "./packet.ts";
 
-
 /**
  * Class that handles WebSocket messages.
  * Uses Client objects and an EventHandler object
@@ -26,7 +25,6 @@ export class Sono {
     this.handleWs = this.handleWs.bind(this);
   }
 
-
   /**
    * Adding a channel to channelsList object
    * @param { name } - name of channel
@@ -38,11 +36,13 @@ export class Sono {
     return;
   }
 
-  connect(req: Request, callback: () => void) {
+  connect(
+    req: Request,
+    callback: () => void = () => console.log("websocket created")
+  ) {
     // @ts-ignore
-    const { socket, response }: { socket: WebSocket, response: Response } = Deno.upgradeWebSocket(req);
+    const { socket, response }: { socket: WebSocket; response: Response } = Deno.upgradeWebSocket(req);
     this.handleWs(socket);
-    this.emit("new client connected");
     callback();
     return response;
   }
@@ -75,7 +75,7 @@ export class Sono {
     });
     socket.addEventListener("message", (event) => {
       const message = event.data;
-      console.log(message);
+      // console.log(message);
       const data: Packet = JSON.parse(message);
       // const event = new Event(data.protocol)
       // const grab = data.payload.message;


### PR DESCRIPTION
## Description

Hello, I really like the sono.land project! When I started Deno and wanted to implement some related features, I found that it didn't run very well on my Deno version 1.42.3. So I forked this repository and improved the source code based on Deno's documentation about websockets. It runs well in my deno-script and I hope to upgrade the sono version on deno.land.

## Reproduction steps

just run it in latest Deno version

```js
import { Sono } from "https://denopkg.dev/gh/KonghaYao/sono.land@main/src/server.ts?33";
const sono = new Sono();
Deno.serve(async (req) => {
    return sono.connect(req);
});

```

## Checklist

- [x] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [x] I've added tests that fail without this PR but pass with it
- [x] I've linted, tested, and commented my code
- [x] I've updated documentation (if appropriate)
